### PR TITLE
Update ProcessEngineCoverageTestExecutionListener.kt for  spring 7 and 8

### DIFF
--- a/extension/spring-test-platform-7/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform7/ProcessEngineCoverageTestExecutionListener.kt
+++ b/extension/spring-test-platform-7/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform7/ProcessEngineCoverageTestExecutionListener.kt
@@ -108,12 +108,12 @@ class ProcessEngineCoverageTestExecutionListener : TestExecutionListener, Ordere
             // Log coverage percentage
             logger.info("${suite.name} test class coverage is: $suiteCoveragePercentage")
             logCoverageDetail(suite)
-
-            assertCoverage(suiteCoveragePercentage, processEngineCoverageProperties.classCoverageAssertionConditions)
-
+            
             // Create graphical report
             CoverageReportUtil.createReport(coverageCollector)
             CoverageReportUtil.createJsonReport(coverageCollector)
+
+            assertCoverage(suiteCoveragePercentage, processEngineCoverageProperties.classCoverageAssertionConditions)
         }
     }
 

--- a/extension/spring-test-platform-8/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform8/ProcessEngineCoverageTestExecutionListener.kt
+++ b/extension/spring-test-platform-8/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform8/ProcessEngineCoverageTestExecutionListener.kt
@@ -116,12 +116,12 @@ class ProcessEngineCoverageTestExecutionListener : TestExecutionListener, Ordere
             // Log coverage percentage
             logger.info("${suite.name} test class coverage is: $suiteCoveragePercentage")
             logCoverageDetail(suite)
-
-            assertCoverage(suiteCoveragePercentage, processEngineCoverageProperties.classCoverageAssertionConditions)
-
+            
             // Create graphical report
             CoverageReportUtil.createReport(coverageCollector)
             CoverageReportUtil.createJsonReport(coverageCollector)
+
+            assertCoverage(suiteCoveragePercentage, processEngineCoverageProperties.classCoverageAssertionConditions)
         }
     }
 


### PR DESCRIPTION
Generate repports before assertCovarage, otherwise the repports is only generate if it has passed the assertCovarage.