### PR TITLE
deletes old repports for spring 7 and 8

### DIFF
--- a/extension/report-generator/src/main/java/org/camunda/community/process_test_coverage/report/CoverageReportUtil.java
+++ b/extension/report-generator/src/main/java/org/camunda/community/process_test_coverage/report/CoverageReportUtil.java
@@ -34,6 +34,14 @@ public class CoverageReportUtil {
     public static final String REPORT_RESOURCES = "static";
     private static final String REPORT_TEMPLATE = "bpmn.report-template.html";
 
+    public static void deleteRepports(final DefaultCollector coverageCollector) {
+        var directory = new File(getReportDirectoryPath(coverageCollector.getActiveSuite().getName()));
+        try {
+            FileUtils.cleanDirectory(directory);
+        } catch (IOException ex) {
+            throw new RuntimeException("Unable to clean directory: " + directory.getName() , ex);
+        }
+    }
 
     public static void createReport(final DefaultCollector coverageCollector) {
         writeReport(createCoverageStateResult(coverageCollector), true,

--- a/extension/report-generator/src/main/java/org/camunda/community/process_test_coverage/report/CoverageReportUtil.java
+++ b/extension/report-generator/src/main/java/org/camunda/community/process_test_coverage/report/CoverageReportUtil.java
@@ -34,7 +34,7 @@ public class CoverageReportUtil {
     public static final String REPORT_RESOURCES = "static";
     private static final String REPORT_TEMPLATE = "bpmn.report-template.html";
 
-    public static void deleteRepports(final DefaultCollector coverageCollector) {
+    public static void deleteReports(final DefaultCollector coverageCollector) {
         var directory = new File(getReportDirectoryPath(coverageCollector.getActiveSuite().getName()));
         try {
             FileUtils.cleanDirectory(directory);

--- a/extension/spring-test-platform-7/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform7/ProcessEngineCoverageTestExecutionListener.kt
+++ b/extension/spring-test-platform-7/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform7/ProcessEngineCoverageTestExecutionListener.kt
@@ -82,7 +82,7 @@ class ProcessEngineCoverageTestExecutionListener : TestExecutionListener, Ordere
             initializeSuite(testContext)
 
             // Delete repports from previously runs
-            CoverageReportUtil.deleteRepports(coverageCollector);
+            CoverageReportUtil.deleteReports(coverageCollector);
         }
     }
 

--- a/extension/spring-test-platform-7/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform7/ProcessEngineCoverageTestExecutionListener.kt
+++ b/extension/spring-test-platform-7/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform7/ProcessEngineCoverageTestExecutionListener.kt
@@ -80,6 +80,9 @@ class ProcessEngineCoverageTestExecutionListener : TestExecutionListener, Ordere
             loadConfiguration(testContext)
             ProcessEngineAdapter(getProcessEngine(testContext), coverageCollector).initializeListeners()
             initializeSuite(testContext)
+
+            // Delete repports from previously runs
+            CoverageReportUtil.deleteRepports(coverageCollector);
         }
     }
 

--- a/extension/spring-test-platform-8/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform8/ProcessEngineCoverageTestExecutionListener.kt
+++ b/extension/spring-test-platform-8/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform8/ProcessEngineCoverageTestExecutionListener.kt
@@ -87,6 +87,8 @@ class ProcessEngineCoverageTestExecutionListener : TestExecutionListener, Ordere
         if (!isTestClassExcluded(testContext)) {
             loadConfiguration(testContext)
             initializeSuite(testContext)
+            // Delete repports from previously runs
+            CoverageReportUtil.deleteRepports(coverageCollector);
         }
     }
 

--- a/extension/spring-test-platform-8/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform8/ProcessEngineCoverageTestExecutionListener.kt
+++ b/extension/spring-test-platform-8/src/main/kotlin/org/camunda/community/process_test_coverage/spring_test/platform8/ProcessEngineCoverageTestExecutionListener.kt
@@ -88,7 +88,7 @@ class ProcessEngineCoverageTestExecutionListener : TestExecutionListener, Ordere
             loadConfiguration(testContext)
             initializeSuite(testContext)
             // Delete repports from previously runs
-            CoverageReportUtil.deleteRepports(coverageCollector);
+            CoverageReportUtil.deleteReports(coverageCollector);
         }
     }
 


### PR DESCRIPTION
I think for testing purpose it's important to delete the previously reported when a new test is ran.

If a report is create after that, you chose to change the test name and run the test again.
Now you have two reports in your  directory